### PR TITLE
Add v1.0 Docs Link to Landing Page

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.0-beta.2"
+APP_VERSION = "2.0.0-beta.3"
 
 
 def load_database_config(config_file_path: str = "config.json") -> Dict[str, Any]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,4 @@ email-validator==1.1.3
 requests==2.26.0
 
 # Include wwdtm>=2.0.0
--e git+https://github.com/questionlp/wwdtm.git#egg=wwdtm
+-e git+https://github.com/questionlp/wwdtm.git@develop#egg=wwdtm

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,10 +17,13 @@
 
     <main>
         <div class="page-link">
-            <a class="links" href="/v2.0/docs">API Documentation →</a>
+            <a class="links" href="/v1.0/docs">API v1.0 Documentation →</a>
         </div>
         <div class="page-link">
-            <a class="links" href="/v2.0/openapi">Try out the API →</a>
+            <a class="links" href="/v2.0/docs">API v2.0 Documentation →</a>
+        </div>
+        <div class="page-link">
+            <a class="links" href="/v2.0/openapi">Try out API v2.0 →</a>
         </div>
         <div class="page-link">
             <a class="links" href="https://stats.wwdt.me/">Stats Page →</a>


### PR DESCRIPTION
Adding link to existing API v1.0 docs to landing page as API v2.0 is closer to launch