### PR TITLE
Update to FastAPI 0.72.0 and Set Minimum Pool Size to 8

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,9 @@ def load_database_config(config_file_path: str = "config.json",
             if "pool_size" not in database_config or not database_config["pool_size"]:
                 database_config["pool_size"] = connection_pool_size
 
+            if "pool_size" in database_config and database_config["pool_size"] < 8:
+                database_config["pool_size"] = 8
+
             del database_config["use_pool"]
         else:
             if "pool_name" in database_config:

--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.0-beta.5"
+APP_VERSION = "2.0.0-beta.6"
 
 
 def load_database_config(config_file_path: str = "config.json",

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,11 @@ app = FastAPI(
     openapi_url=f"/v{API_VERSION}/openapi.json",
     redoc_url=f"/v{API_VERSION}/docs",
     docs_url=f"/v{API_VERSION}/openapi",
+    swagger_ui_parameters={
+        "deepLinking": False,
+        "defaultModelsExpandDepth": 0,
+        "syntaxHighlight.theme": "arta",
+    },
 )
 
 app.mount("/static",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,10 +2,9 @@ flake8>=4.0.1
 pycodestyle>=2.8.0
 pytest==6.2.5
 
-fastapi==0.71.0
-uvicorn[standard]==0.16.0
+fastapi==0.72.0
+uvicorn[standard]==0.17.0
 gunicorn==20.1.0
-pydantic==1.9.0
 aiofiles==0.8.0
 jinja2==3.0.3
 email-validator==1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-fastapi==0.71.0
-uvicorn[standard]==0.16.0
+fastapi==0.72.0
+uvicorn[standard]==0.17.0
 gunicorn==20.1.0
-pydantic==1.9.0
 aiofiles==0.8.0
 jinja2==3.0.3
 email-validator==1.1.3


### PR DESCRIPTION
* Bump the version of FastAPI to 0.72.0 and uvicorn to 0.17.0
* Customize Swagger UI settings to include:
  - Use `arta` as the syntax highlighting color scheme
  - Don't expand the `Schemas` section by default
  - Do not enable deep-linking
* Add logic to set the minimum MySQL Connector pool size to 8, while maintaining a default size of 10 if not defined, if connection pooling is enabled